### PR TITLE
feat: tweak docker workflow to tag `:dev` when not main

### DIFF
--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -75,4 +75,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/${{ matrix.package }}:${{ inputs.branch == 'main' && 'v1' || 'dev' }}
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.package }}:latest
+            ${{ inputs.branch == 'main' && format('ghcr.io/{0}/{1}:latest', github.repository_owner, matrix.package) }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build and push workflow to consistently build and push images across all branches. Main branch releases are tagged as `v1` and `latest`, while other branches use `dev` tags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->