### PR TITLE
feat: add git-cliff changelog generation

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,78 @@
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT-0
+
+name: "📝 Update Changelog"
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write # Needed to push to the update branch
+  pull-requests: write # Needed to create/update the pull request
+
+concurrency:
+  group: update-changelog
+  cancel-in-progress: true
+
+jobs:
+  update-changelog:
+    name: "📝 Update Unreleased Changelog"
+    runs-on: ubuntu-slim
+    steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: 🔧 Install git-cliff
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+        with:
+          crate: git-cliff
+          version: 2.13.1
+          locked: true
+
+      - name: 📝 Generate changelog
+        run: git-cliff --output CHANGELOG.md
+
+      - name: ⚙️ Set up SSH signing key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_SIGNING_KEY }}" > ~/.ssh/id_ed25519_signing
+          chmod 600 ~/.ssh/id_ed25519_signing
+          git config --global gpg.format ssh
+          git config --global user.signingKey ~/.ssh/id_ed25519_signing
+          git config --global user.name "hrzlgnm"
+          git config --global user.email "hrzlgnm@users.noreply.github.com"
+
+      - name: 🔁 Create or update Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GH_CONTENT_WRITE }}
+        run: |
+          if git diff --quiet CHANGELOG.md; then
+            echo "No changes to changelog"
+            exit 0
+          fi
+
+          BRANCH="chore/update-changelog"
+          git checkout -B "$BRANCH"
+          git add CHANGELOG.md
+          git commit -S -m "chore(version): update unreleased changelog"
+          git push --force-with-lease origin "$BRANCH"
+
+          if [ "$(gh pr list --head "$BRANCH" --state open --json number --jq 'length')" = "0" ]; then
+            gh pr create \
+              --title "chore: update unreleased changelog" \
+              --body "Automated update of the \`[Unreleased]\` section in \`CHANGELOG.md\`.
+
+          This PR is created automatically on every push to \`main\`
+          by running \`git-cliff\` without a version tag." \
+              --label ignore
+          fi
+
+          gh pr merge "$BRANCH" --auto --squash
+
+      - name: 🧹 Cleanup SSH signing key
+        if: always()
+        run: rm -f ~/.ssh/id_ed25519_signing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/cliff.toml
+++ b/cliff.toml
@@ -32,13 +32,7 @@ body = """
 """
 trim = true
 footer = ""
-postprocessors = [
-    { pattern = 'Simlify', replace = 'Simplify' },
-    { pattern = 'hanlding', replace = 'handling' },
-    { pattern = 'verision', replace = 'version' },
-    { pattern = 'compileable', replace = 'compilable' },
-    { pattern = 'thouroughly', replace = 'thoroughly' },
-]
+postprocessors = []
 
 [git]
 conventional_commits = true

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,76 @@
+[changelog]
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+body = """
+{% if version -%}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }} {%- if previous and previous.version %} [compare](https://github.com/hrzlgnm/actions/compare/{{ previous.version }}...{{ version }}){% endif %}\n
+{% else -%}\
+    ## [Unreleased] {%- if commits and previous and previous.version %} [compare](https://github.com/hrzlgnm/actions/compare/{{ previous.version }}...HEAD){% endif %}\n
+{% endif -%}\
+{% for group, commits in commits | group_by(attribute="group") %}\
+    {% if group == "Added" -%}\
+        ### Added\n
+    {% elif group == "Fixed" -%}\
+        ### Fixed\n
+    {% elif group == "Changed" -%}\
+        ### Changed\n
+    {% elif group == "Security" -%}\
+        ### Security\n
+    {% elif group == "Miscellaneous" -%}\
+        ### Miscellaneous\n
+    {% endif -%}\
+    {% for commit in commits -%}\
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif -%}\
+            {{ commit.message | upper_first | trim }}\
+            {% for link in commit.links %} ([{{ link.text }}]({{ link.href }})){% endfor %}\n
+    {% endfor -%}\
+{% endfor %}\
+"""
+trim = true
+footer = ""
+postprocessors = [
+    { pattern = 'Simlify', replace = 'Simplify' },
+    { pattern = 'hanlding', replace = 'handling' },
+    { pattern = 'verision', replace = 'version' },
+    { pattern = 'compileable', replace = 'compilable' },
+    { pattern = 'thouroughly', replace = 'thoroughly' },
+]
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^feat", group = "Added" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^doc", group = "Changed" },
+    { message = "^perf", group = "Changed" },
+    { message = "^refactor", group = "Changed" },
+    { message = "^style", group = "Changed" },
+    { message = "^test", group = "Changed" },
+    { message = "^ci", group = "Miscellaneous" },
+    { message = "^build", group = "Miscellaneous" },
+    { message = "^chore\\(deps\\)", skip = true },
+    { message = "^chore\\(renovate", skip = true },
+    { message = "^chore: update unreleased changelog", skip = true },
+    { message = "^chore", group = "Changed" },
+    { message = "^security", group = "Security" },
+    { message = "^GHSA-", group = "Security" },
+    { message = "^Bump version", skip = true },
+]
+protect_breaking_commits = true
+filter_commits = true
+tag_pattern = "v[0-9].*"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"
+link_parsers = [
+    { pattern = "#(\\d+)", text = "#${1}", href = "https://github.com/hrzlgnm/actions/pull/${1}" },
+]
+include_paths = []
+exclude_paths = []


### PR DESCRIPTION
Adds changelog generation using git-cliff, copied from the approach in mdns-tui-browser.

**Changes:**
- `cliff.toml` - git-cliff configuration with conventional commit parsing
- `CHANGELOG.md` - initial changelog with empty `\[Unreleased\]` section
- `.github/workflows/update-changelog.yml` - workflow that regenerates the `\[Unreleased]` section on every push to `main`

**Required secrets:** `SSH_SIGNING_KEY`, `GH_CONTENT_WRITE`