### PR TITLE
fix(ci): add rust toolchain to changelog workflow

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: ⚙️ Install Rust
+        uses: dtolnay/rust-toolchain@00b86db6e1305cef653c3d9289401e8e43e8e0eb # stable
+
       - name: 🔧 Install git-cliff
         uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
         with:


### PR DESCRIPTION
The `cargo-install` action requires cargo to be available, but `ubuntu-slim` does not ship with Rust pre-installed. Adds `dtolnay/rust-toolchain` step before `baptiste0928/cargo-install`.