### PR TITLE
feat: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,29 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ruleset-modification
+  cancel-in-progress: false
+
 jobs:
   release:
     name: "🚀 Release"
     runs-on: ubuntu-slim
+    env:
+      GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+      RULESET: repos/${{ github.repository }}/rulesets/${{ secrets.RULESET_ID }}
     steps:
+      - name: 🛡️ Verify RULESET_ID secret is configured
+        run: |
+          if [ -z "${{ secrets.RULESET_ID }}" ]; then
+            echo "Error: secrets.RULESET_ID is not set. Please configure the RULESET_ID secret in repository settings."
+            echo "This secret should contain the ID of the ruleset used to disable enforcement during version bump."
+            exit 1
+          fi
+          echo "RULESET_ID secret is configured"
+
       - name: 📋 Get draft release version
         id: draft
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG=$(gh release list --draft --json tagName --jq '.[0].tagName')
           if [ -z "$TAG" ]; then
@@ -67,10 +81,15 @@ jobs:
           git commit -S -m "chore(version): update changelog for $TAG"
 
       - name: 🔓 Disable branch protection
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RULESET_ID: ${{ secrets.RULESET_ID }}
-        run: gh api "repos/{owner}/{repo}/rulesets/$RULESET_ID" -X PUT -f enforcement="disabled"
+        run: |
+          gh api \
+          -H "Accept: application/vnd.github+json" \
+          "${RULESET}" | jq '.enforcement = "disabled"' | \
+          gh api \
+          --method PUT \
+          -H "Accept: application/vnd.github+json" \
+          "${RULESET}" \
+          --input -
 
       - name: 📤 Push to main
         env:
@@ -81,10 +100,15 @@ jobs:
 
       - name: 🔒 Re-enable branch protection
         if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RULESET_ID: ${{ secrets.RULESET_ID }}
-        run: gh api "repos/{owner}/{repo}/rulesets/$RULESET_ID" -X PUT -f enforcement="active"
+        run: |
+          gh api \
+          -H "Accept: application/vnd.github+json" \
+          "${RULESET}" | jq '.enforcement = "active"' | \
+          gh api \
+          --method PUT \
+          -H "Accept: application/vnd.github+json" \
+          "${RULESET}" \
+          --input -
 
       - name: 🏷️ Create tag
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       - name: 🔄 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          ref: main
           fetch-depth: 0
 
       - name: ⚙️ Install Rust
@@ -68,21 +69,27 @@ jobs:
       - name: 🔓 Disable branch protection
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh api "repos/{owner}/{repo}/rulesets/10506365" -X PATCH -f enforcement="disabled"
+        run: gh api "repos/{owner}/{repo}/rulesets/10506365" -X PUT -f enforcement="disabled"
 
       - name: 📤 Push to main
-        run: git push origin main
+        env:
+          GH_TOKEN: ${{ secrets.GH_CONTENT_WRITE }}
+        run: |
+          git remote set-url origin "https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+          git push origin main
 
       - name: 🔒 Re-enable branch protection
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh api "repos/{owner}/{repo}/rulesets/10506365" -X PATCH -f enforcement="active"
+        run: gh api "repos/{owner}/{repo}/rulesets/10506365" -X PUT -f enforcement="active"
 
       - name: 🏷️ Create tag
         env:
           TAG: ${{ steps.draft.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GH_CONTENT_WRITE }}
         run: |
+          git remote set-url origin "https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY.git"
           git tag "$TAG"
           git push origin "$TAG"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,8 @@ jobs:
       - name: 🔓 Disable branch protection
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh api "repos/{owner}/{repo}/rulesets/10506365" -X PUT -f enforcement="disabled"
+          RULESET_ID: ${{ secrets.RULESET_ID }}
+        run: gh api "repos/{owner}/{repo}/rulesets/$RULESET_ID" -X PUT -f enforcement="disabled"
 
       - name: 📤 Push to main
         env:
@@ -82,7 +83,8 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh api "repos/{owner}/{repo}/rulesets/10506365" -X PUT -f enforcement="active"
+          RULESET_ID: ${{ secrets.RULESET_ID }}
+        run: gh api "repos/{owner}/{repo}/rulesets/$RULESET_ID" -X PUT -f enforcement="active"
 
       - name: 🏷️ Create tag
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
       RULESET: repos/${{ github.repository }}/rulesets/${{ secrets.RULESET_ID }}
     steps:
-      - name: 🛡️ Verify RULESET_ID secret is configured
+      - name: 🛡️ Verify secrets are configured
         run: |
           if [ -z "${{ secrets.RULESET_ID }}" ]; then
             echo "Error: secrets.RULESET_ID is not set. Please configure the RULESET_ID secret in repository settings."
             echo "This secret should contain the ID of the ruleset used to disable enforcement during version bump."
             exit 1
           fi
-          echo "RULESET_ID secret is configured"
+          if [ -z "${{ secrets.GH_ADMIN_TOKEN }}" ]; then
+            echo "Error: secrets.GH_ADMIN_TOKEN is not set. Please configure the GH_ADMIN_TOKEN secret in repository settings."
+            echo "This secret should contain a PAT with administration write access for ruleset management."
+            exit 1
+          fi
+          echo "All required secrets are configured"
 
       - name: 📋 Get draft release version
         id: draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT-0
+
+name: "🚀 Release"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: "🚀 Release"
+    runs-on: ubuntu-slim
+    steps:
+      - name: 📋 Get draft release version
+        id: draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=$(gh release list --draft --json tagName --jq '.[0].tagName')
+          if [ -z "$TAG" ]; then
+            echo "No draft release found"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: 🔄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: ⚙️ Install Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      - name: 🔧 Install git-cliff
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+        with:
+          crate: git-cliff
+          version: 2.13.1
+          locked: true
+
+      - name: 📝 Generate changelog
+        env:
+          TAG: ${{ steps.draft.outputs.tag }}
+        run: git-cliff --tag "$TAG" --output CHANGELOG.md
+
+      - name: ⚙️ Set up SSH signing key
+        env:
+          SSH_KEY: ${{ secrets.SSH_SIGNING_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/id_ed25519_signing
+          chmod 600 ~/.ssh/id_ed25519_signing
+          git config --global gpg.format ssh
+          git config --global user.signingKey ~/.ssh/id_ed25519_signing
+          git config --global user.name "hrzlgnm"
+          git config --global user.email "hrzlgnm@users.noreply.github.com"
+
+      - name: 📝 Commit changelog
+        env:
+          TAG: ${{ steps.draft.outputs.tag }}
+        run: |
+          git add CHANGELOG.md
+          git commit -S -m "chore(version): update changelog for $TAG"
+
+      - name: 🔓 Disable branch protection
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh api "repos/{owner}/{repo}/rulesets/10506365" -X PATCH -f enforcement="disabled"
+
+      - name: 📤 Push to main
+        run: git push origin main
+
+      - name: 🔒 Re-enable branch protection
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh api "repos/{owner}/{repo}/rulesets/10506365" -X PATCH -f enforcement="active"
+
+      - name: 🏷️ Create tag
+        env:
+          TAG: ${{ steps.draft.outputs.tag }}
+        run: |
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: 🚀 Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.draft.outputs.tag }}
+        run: gh release edit "$TAG" --draft=false --target main
+
+      - name: 🧹 Cleanup SSH signing key
+        if: always()
+        run: rm -f ~/.ssh/id_ed25519_signing


### PR DESCRIPTION
Adds a release workflow that generates a versioned changelog before creating the tag, ensuring the tag points to the commit with the correct changelog.

## What this does

1. Gets version from the latest draft release
2. Generates changelog with `git-cliff --tag <version>`
3. Commits to main (with temporary branch protection bypass)
4. Creates git tag at that commit
5. Publishes the draft release

The tag is created AFTER the changelog commit, so it points to the correct version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered release workflow.
  * Automates changelog generation, signed commits, tagging, and publishing draft releases.
  * Restores repository protections and cleans up signing credentials after completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->