### PR TITLE
chore: update unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] [compare](https://github.com/hrzlgnm/actions/compare/v2.3.1...HEAD)
+## [Unreleased] [compare](https://github.com/hrzlgnm/actions/compare/v2.4.0...HEAD)
+
+### Added
+
+- Add release workflow (#171) ([#171](https://github.com/hrzlgnm/actions/pull/171))
+
+## [2.4.0] - 2026-07-26 [compare](https://github.com/hrzlgnm/actions/compare/v2.3.1...v2.4.0)
 
 ### Added
 


### PR DESCRIPTION
Automated update of the `[Unreleased]` section in `CHANGELOG.md`.

This PR is created automatically on every push to `main`
by running `git-cliff` without a version tag.