### PR TITLE
fix: use shared concurrency group to prevent workflow races

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: release-operations
+  cancel-in-progress: false
+
 jobs:
   update_release_draft:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,34 @@ jobs:
           fi
           echo "All required secrets are configured"
 
+      - name: ⏳ Wait for release-drafter to finish
+        run: |
+          echo "Checking for running release-drafter workflows..."
+          while true; do
+            RUNNING=$(gh api "repos/${{ github.repository }}/actions/workflows/release-drafter.yml/runs" \
+              --jq '.workflow_runs[] | select(.status == "in_progress" or .status == "queued") | .id' 2>/dev/null | wc -l)
+            if [ "$RUNNING" -eq 0 ]; then
+              echo "No release-drafter workflows running"
+              break
+            fi
+            echo "Found $RUNNING running release-drafter workflow(s), waiting 30s..."
+            sleep 30
+          done
+
+      - name: ⏳ Wait for update-changelog to finish
+        run: |
+          echo "Checking for running update-changelog workflows..."
+          while true; do
+            RUNNING=$(gh api "repos/${{ github.repository }}/actions/workflows/update-changelog.yml/runs" \
+              --jq '.workflow_runs[] | select(.status == "in_progress" or .status == "queued") | .id' 2>/dev/null | wc -l)
+            if [ "$RUNNING" -eq 0 ]; then
+              echo "No update-changelog workflows running"
+              break
+            fi
+            echo "Found $RUNNING running update-changelog workflow(s), waiting 30s..."
+            sleep 30
+          done
+
       - name: 📋 Get draft release version
         id: draft
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
         run: |
           echo "Checking for running release-drafter workflows..."
           while true; do
-            RUNNING=$(gh api "repos/${{ github.repository }}/actions/workflows/release-drafter.yml/runs" \
-              --jq '.workflow_runs[] | select(.status == "in_progress" or .status == "queued") | .id' 2>/dev/null | wc -l)
+            RUNNING=$(gh api --paginate "repos/${{ github.repository }}/actions/workflows/release-drafter.yml/runs" \
+              --jq '.workflow_runs[] | select(.status == "requested" or .status == "waiting" or .status == "pending" or .status == "queued" or .status == "in_progress") | .id' 2>/dev/null | wc -l)
             if [ "$RUNNING" -eq 0 ]; then
               echo "No release-drafter workflows running"
               break
@@ -53,8 +53,8 @@ jobs:
         run: |
           echo "Checking for running update-changelog workflows..."
           while true; do
-            RUNNING=$(gh api "repos/${{ github.repository }}/actions/workflows/update-changelog.yml/runs" \
-              --jq '.workflow_runs[] | select(.status == "in_progress" or .status == "queued") | .id' 2>/dev/null | wc -l)
+            RUNNING=$(gh api --paginate "repos/${{ github.repository }}/actions/workflows/update-changelog.yml/runs" \
+              --jq '.workflow_runs[] | select(.status == "requested" or .status == "waiting" or .status == "pending" or .status == "queued" or .status == "in_progress") | .id' 2>/dev/null | wc -l)
             if [ "$RUNNING" -eq 0 ]; then
               echo "No update-changelog workflows running"
               break

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: ruleset-modification
+  group: release-operations
   cancel-in-progress: false
 
 jobs:
@@ -34,34 +34,6 @@ jobs:
             exit 1
           fi
           echo "All required secrets are configured"
-
-      - name: ⏳ Wait for release-drafter to finish
-        run: |
-          echo "Checking for running release-drafter workflows..."
-          while true; do
-            RUNNING=$(gh api --paginate "repos/${{ github.repository }}/actions/workflows/release-drafter.yml/runs" \
-              --jq '.workflow_runs[] | select(.status == "requested" or .status == "waiting" or .status == "pending" or .status == "queued" or .status == "in_progress") | .id' 2>/dev/null | wc -l)
-            if [ "$RUNNING" -eq 0 ]; then
-              echo "No release-drafter workflows running"
-              break
-            fi
-            echo "Found $RUNNING running release-drafter workflow(s), waiting 30s..."
-            sleep 30
-          done
-
-      - name: ⏳ Wait for update-changelog to finish
-        run: |
-          echo "Checking for running update-changelog workflows..."
-          while true; do
-            RUNNING=$(gh api --paginate "repos/${{ github.repository }}/actions/workflows/update-changelog.yml/runs" \
-              --jq '.workflow_runs[] | select(.status == "requested" or .status == "waiting" or .status == "pending" or .status == "queued" or .status == "in_progress") | .id' 2>/dev/null | wc -l)
-            if [ "$RUNNING" -eq 0 ]; then
-              echo "No update-changelog workflows running"
-              break
-            fi
-            echo "Found $RUNNING running update-changelog workflow(s), waiting 30s..."
-            sleep 30
-          done
 
       - name: 📋 Get draft release version
         id: draft

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: release-operations
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   update-changelog:

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write # Needed to create/update the pull request
 
 concurrency:
-  group: update-changelog
+  group: release-operations
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Uses a shared concurrency group `release-operations` across release.yml, release-drafter.yml, and update-changelog.yml to prevent parallel workflow execution.

This eliminates race conditions between:
- Changelog updates (update-changelog.yml)
- Draft release creation (release-drafter.yml)
- Release publishing (release.yml)

GitHub Actions automatically queues workflows in the same concurrency group, so no polling is needed.