### PR TITLE
chore: update unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add release workflow (#171) ([#171](https://github.com/hrzlgnm/actions/pull/171))
 
+### Fixed
+
+- Use shared concurrency group to prevent workflow races (#173) ([#173](https://github.com/hrzlgnm/actions/pull/173))
+
 ## [2.4.0] - 2026-07-26 [compare](https://github.com/hrzlgnm/actions/compare/v2.3.1...v2.4.0)
 
 ### Added


### PR DESCRIPTION
Automated update of the `[Unreleased]` section in `CHANGELOG.md`.

This PR is created automatically on every push to `main`
by running `git-cliff` without a version tag.