### PR TITLE
fix: use gh api instead of invalid --draft flag for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: 📋 Get draft release version
         id: draft
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           TAG=$(gh release list -R "${{ github.repository }}" --json tagName,isDraft --jq 'map(select(.isDraft)) | .[0].tagName')
           if [ -z "$TAG" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: 📋 Get draft release version
         id: draft
         run: |
-          TAG=$(gh release list --draft --json tagName --jq '.[0].tagName')
+          TAG=$(gh api "repos/${{ github.repository }}/releases" --jq 'map(select(.draft)) | .[0].tag_name')
           if [ -z "$TAG" ]; then
             echo "No draft release found"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: 📋 Get draft release version
         id: draft
         run: |
-          TAG=$(gh api "repos/${{ github.repository }}/releases" --jq 'map(select(.draft)) | .[0].tag_name')
+          TAG=$(gh release list --json tagName,isDraft --jq 'map(select(.isDraft)) | .[0].tagName')
           if [ -z "$TAG" ]; then
             echo "No draft release found"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: 📋 Get draft release version
         id: draft
         run: |
-          TAG=$(gh release list --json tagName,isDraft --jq 'map(select(.isDraft)) | .[0].tagName')
+          TAG=$(gh release list -R "${{ github.repository }}" --json tagName,isDraft --jq 'map(select(.isDraft)) | .[0].tagName')
           if [ -z "$TAG" ]; then
             echo "No draft release found"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG=$(gh release list -R "${{ github.repository }}" --json tagName,isDraft --jq 'map(select(.isDraft)) | .[0].tagName')
+          TAG=$(gh api "/repos/${{ github.repository }}/releases?per_page=100" --paginate | jq -s 'map(.[]) | map(select(.draft)) | .[0].tag_name // empty')
           if [ -z "$TAG" ]; then
             echo "No draft release found"
             exit 1


### PR DESCRIPTION
The `gh release list --draft` flag doesn't exist in the GitHub CLI. Replaced with direct API call that filters for draft releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved draft release version detection in the release workflow.
  * Preserved validation to prevent releases when no draft version is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->