### PR TITLE
chore: update unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] [compare](https://github.com/hrzlgnm/actions/compare/v2.5.0...HEAD)
+
+### Fixed
+
+- Use gh api instead of invalid --draft flag for releases (#176) ([#176](https://github.com/hrzlgnm/actions/pull/176))
+
 ## [2.5.0] - 2026-07-28 [compare](https://github.com/hrzlgnm/actions/compare/v2.4.0...v2.5.0)
 
 ### Added
 
 - Add release workflow (#171) ([#171](https://github.com/hrzlgnm/actions/pull/171))
+
+### Changed
+
+- *(version)* Update changelog for v2.5.0
 
 ### Fixed
 


### PR DESCRIPTION
Automated update of the `[Unreleased]` section in `CHANGELOG.md`.

This PR is created automatically on every push to `main`
by running `git-cliff` without a version tag.