### PR TITLE
fix: add -r flag to jq to strip JSON quotes from tag name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG=$(gh api "/repos/${{ github.repository }}/releases?per_page=100" --paginate | jq -s 'map(.[]) | map(select(.draft)) | .[0].tag_name // empty')
+          TAG=$(gh api "/repos/${{ github.repository }}/releases?per_page=100" --paginate | jq -rs 'map(.[]) | map(select(.draft)) | .[0].tag_name // empty')
           if [ -z "$TAG" ]; then
             echo "No draft release found"
             exit 1


### PR DESCRIPTION
jq -s outputs JSON-encoded strings with quotes, causing `TAG` to contain literal double quotes (`"v2.5.1"`). This led to:\n- git tag creating a tag literally named \"v2.5.1\"\n- gh release edit failing with \"release not found\" since the draft tag name had no quotes\n\nFix: `jq -rs` outputs raw strings without JSON quoting.