### PR TITLE
fix: isolate workflow concurrency groups and add AGENTS.md

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: release-operations
+  group: release-drafter
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: release-operations
+  group: release
   cancel-in-progress: false
 
 jobs:
@@ -21,6 +21,33 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
       RULESET: repos/${{ github.repository }}/rulesets/${{ secrets.RULESET_ID }}
     steps:
+      - name: ⏳ Wait for CI, release-drafter, and update-changelog to finish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          FAILED=0
+          for entry in "CI ci.yml" "release-drafter release-drafter.yml" "update-changelog update-changelog.yml"; do
+            read -r name file <<< "$entry"
+            echo "Checking for in-progress $name runs..."
+            for _ in $(seq 1 40); do
+              RUNS=$(gh api "repos/$REPO/actions/workflows/$file/runs?status=in_progress&per_page=10" \
+                --jq '[.workflow_runs[] | select(.status == "in_progress" or .status == "queued" or .status == "pending") | .id]')
+              COUNT=$(echo "$RUNS" | jq 'length')
+              if [ "$COUNT" -eq 0 ]; then
+                echo "No pending $name runs, proceeding"
+                break
+              fi
+              echo "Waiting for $COUNT $name run(s): $(echo "$RUNS" | jq -c '.') — sleeping 15s..."
+              sleep 15
+            done
+            if [ "$COUNT" -gt 0 ]; then
+              echo "Timed out waiting for $name runs to complete"
+              FAILED=1
+            fi
+          done
+          [ "$FAILED" -eq 0 ] || exit 1
+
       - name: 🛡️ Verify secrets are configured
         run: |
           if [ -z "${{ secrets.RULESET_ID }}" ]; then

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write # Needed to create/update the pull request
 
 concurrency:
-  group: release-operations
+  group: update-changelog
   cancel-in-progress: false
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Collection of reusable GitHub Actions workflows. Published for external consumpt
 
 ```sh
 actionlint .github/workflows/*.yml
+typos .
 ```
 
 ## Release process

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md — hrzlgnm/actions
+
+## Project
+
+Collection of reusable GitHub Actions workflows. Published for external consumption via `uses: hrzlgnm/actions/.github/workflows/<file>@<tag>`.
+
+## Conventions
+
+- **Conventional commits** — All commits follow conventional commits format. `git-cliff` parses them for changelogs.
+- **Semantic versioning** — Tags are `vX.Y.Z`.
+- **SSH-signed commits** — Automated commits use SSH signing key from secrets.
+- **Pinned dependencies** — All actions and tools pinned to SHA commit hashes with version comments (e.g. `# v3`). Renovate keeps them updated.
+- **Copyright + SPDX** — Every workflow file has `# Copyright 2026 hrzlgnm` and `# SPDX-License-Identifier: MIT-0` headers.
+- **`${{ }}` forbidden in `run:` blocks** — Use `env` vars instead.
+- **Branch naming** — `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `perf/`, `renovate/`, `deps/` trigger auto-labeling.
+
+## Workflows
+
+| File | Trigger | Purpose |
+|---|---|---|
+| `ci.yml` | push/PR/schedule | Main CI: detect changes, label PRs, typos, actionlint, alls-green gate |
+| `release-drafter.yml` | push main | Delete old drafts, create new draft release |
+| `update-changelog.yml` | push main | Run git-cliff, open auto-merge PR with changelog update |
+| `release.yml` | workflow_dispatch | Wait for CI/changelog/drafter, generate final changelog, push, tag, publish |
+| `typos-reusable.yml` | workflow_call | Spell check with `crate-ci/typos` |
+| `actionlint-reusable.yml` | workflow_call | Lint workflow files |
+| `docker-reusable.yml` | workflow_call | Build & push changed Dockerfiles to GHCR |
+| `retry-failed-ci-reusable.yml` | workflow_call | Retry failed jobs from a given workflow |
+
+## Lint
+
+```sh
+actionlint .github/workflows/*.yml
+```
+
+## Release process
+
+1. Push to `main` triggers `release-drafter` (drafts release) and `update-changelog` (PR with changelog).
+2. Changelog PR auto-merges, triggering another round of drafter + changelog.
+3. Manually dispatch `release.yml` — it waits for all CI/drafter/changelog to finish, generates final changelog, disables branch protection, pushes tags, publishes the draft, re-enables protection.

--- a/typos.toml
+++ b/typos.toml
@@ -7,3 +7,6 @@ extend-exclude = [
 
 [default]
 check-filename = true
+
+[default.extend-words]
+alls = "alls" # used by re-actors/alls-green action


### PR DESCRIPTION
## Changes

- **Separate concurrency groups** — Each workflow now has its own group (`release-drafter`, `update-changelog`, `release`) to prevent cross-workflow cancellation of queued runs.
- **Wait for dependent workflows** — `release.yml` now polls the API to ensure CI, release-drafter, and update-changelog complete before proceeding.
- **AGENTS.md** — Add project conventions for AI coding agents.

Fixes the issue where a pending release-drafter run was auto-cancelled when a newer push triggered the shared `release-operations` group.