### PR TITLE
fix: wait for release workflow in ci.yml to prevent race with auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,28 @@ jobs:
       branch: ${{ steps.branch.outputs.branch }}
       workflows: ${{ steps.filter.outputs.lint }}
     steps:
+      - name: ⏳ Wait for release workflow to finish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "Checking for in-progress release runs..."
+          for _ in $(seq 1 40); do
+            RUNS=$(gh api "repos/$REPO/actions/workflows/release.yml/runs?status=in_progress&per_page=10" \
+              --jq '[.workflow_runs[] | select(.status == "in_progress" or .status == "queued" or .status == "pending") | .id]')
+            COUNT=$(echo "$RUNS" | jq 'length')
+            if [ "$COUNT" -eq 0 ]; then
+              echo "No pending release runs, proceeding"
+              break
+            fi
+            echo "Waiting for $COUNT release run(s): $(echo "$RUNS" | jq -c '.') — sleeping 15s..."
+            sleep 15
+          done
+          if [ "$COUNT" -gt 0 ]; then
+            echo "Timed out waiting for release runs to complete"
+            exit 1
+          fi
+
       - name: 🔄 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -21,6 +21,27 @@ jobs:
     name: "📝 Update Unreleased Changelog"
     runs-on: ubuntu-slim
     steps:
+      - name: ⏳ Wait for release workflow to finish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "Checking for in-progress release runs..."
+          for _ in $(seq 1 40); do
+            RUNS=$(gh api "repos/$REPO/actions/workflows/release.yml/runs?status=in_progress&per_page=10" \
+              --jq '[.workflow_runs[] | select(.status == "in_progress" or .status == "queued" or .status == "pending") | .id]')
+            COUNT=$(echo "$RUNS" | jq 'length')
+            if [ "$COUNT" -eq 0 ]; then
+              echo "No pending release runs, proceeding"
+              break
+            fi
+            echo "Waiting for $COUNT release run(s): $(echo "$RUNS" | jq -c '.') — sleeping 15s..."
+            sleep 15
+          done
+          if [ "$COUNT" -gt 0 ]; then
+            echo "Timed out waiting for release runs to complete"
+            exit 1
+          fi
       - name: 🔄 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,10 @@ actionlint .github/workflows/*.yml
 typos .
 ```
 
+## Workflow
+
+After making a change, commit, push, and create a PR — then stop. Don't wait for CI or follow up.
+
 ## Release process
 
 1. Push to `main` triggers `release-drafter` (drafts release) and `update-changelog` (PR with changelog).


### PR DESCRIPTION
Adds a polling step at the start of CI that waits for any in-progress release workflow to finish before proceeding. This prevents the auto-merge of changelog PRs from racing with the release workflow.