### PR TITLE
fix: break circular wait deadlock between ci, changelog, and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,28 +36,6 @@ jobs:
       branch: ${{ steps.branch.outputs.branch }}
       workflows: ${{ steps.filter.outputs.lint }}
     steps:
-      - name: ⏳ Wait for release workflow to finish
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          echo "Checking for in-progress release runs..."
-          for _ in $(seq 1 40); do
-            RUNS=$(gh api "repos/$REPO/actions/workflows/release.yml/runs?status=in_progress&per_page=10" \
-              --jq '[.workflow_runs[] | select(.status == "in_progress" or .status == "queued" or .status == "pending") | .id]')
-            COUNT=$(echo "$RUNS" | jq 'length')
-            if [ "$COUNT" -eq 0 ]; then
-              echo "No pending release runs, proceeding"
-              break
-            fi
-            echo "Waiting for $COUNT release run(s): $(echo "$RUNS" | jq -c '.') — sleeping 15s..."
-            sleep 15
-          done
-          if [ "$COUNT" -gt 0 ]; then
-            echo "Timed out waiting for release runs to complete"
-            exit 1
-          fi
-
       - name: 🔄 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: release
+  group: release-changelog
   cancel-in-progress: false
 
 jobs:
@@ -21,33 +21,6 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
       RULESET: repos/${{ github.repository }}/rulesets/${{ secrets.RULESET_ID }}
     steps:
-      - name: ⏳ Wait for CI, release-drafter, and update-changelog to finish
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          FAILED=0
-          for entry in "CI ci.yml" "release-drafter release-drafter.yml" "update-changelog update-changelog.yml"; do
-            read -r name file <<< "$entry"
-            echo "Checking for in-progress $name runs..."
-            for _ in $(seq 1 40); do
-              RUNS=$(gh api "repos/$REPO/actions/workflows/$file/runs?status=in_progress&per_page=10" \
-                --jq '[.workflow_runs[] | select(.status == "in_progress" or .status == "queued" or .status == "pending") | .id]')
-              COUNT=$(echo "$RUNS" | jq 'length')
-              if [ "$COUNT" -eq 0 ]; then
-                echo "No pending $name runs, proceeding"
-                break
-              fi
-              echo "Waiting for $COUNT $name run(s): $(echo "$RUNS" | jq -c '.') — sleeping 15s..."
-              sleep 15
-            done
-            if [ "$COUNT" -gt 0 ]; then
-              echo "Timed out waiting for $name runs to complete"
-              FAILED=1
-            fi
-          done
-          [ "$FAILED" -eq 0 ] || exit 1
-
       - name: 🛡️ Verify secrets are configured
         run: |
           if [ -z "${{ secrets.RULESET_ID }}" ]; then

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write # Needed to create/update the pull request
 
 concurrency:
-  group: update-changelog
+  group: release-changelog
   cancel-in-progress: false
 
 jobs:
@@ -21,27 +21,6 @@ jobs:
     name: "📝 Update Unreleased Changelog"
     runs-on: ubuntu-slim
     steps:
-      - name: ⏳ Wait for release workflow to finish
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          echo "Checking for in-progress release runs..."
-          for _ in $(seq 1 40); do
-            RUNS=$(gh api "repos/$REPO/actions/workflows/release.yml/runs?status=in_progress&per_page=10" \
-              --jq '[.workflow_runs[] | select(.status == "in_progress" or .status == "queued" or .status == "pending") | .id]')
-            COUNT=$(echo "$RUNS" | jq 'length')
-            if [ "$COUNT" -eq 0 ]; then
-              echo "No pending release runs, proceeding"
-              break
-            fi
-            echo "Waiting for $COUNT release run(s): $(echo "$RUNS" | jq -c '.') — sleeping 15s..."
-            sleep 15
-          done
-          if [ "$COUNT" -gt 0 ]; then
-            echo "Timed out waiting for release runs to complete"
-            exit 1
-          fi
       - name: 🔄 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:


### PR DESCRIPTION
Replace polling-based cross-workflow waits with a shared `release-changelog` concurrency group between `release.yml` and `update-changelog.yml`. Remove all wait-for-release polling from `ci.yml` and `update-changelog.yml`.

## Deadlock that existed

```
release.yml ──waits for──▶ ci.yml
     ▲                       │
     │                       │ waits for
     │                       ▼
     └── waits for ──── update-changelog.yml
                          (also waits for release.yml)
```

## Fix

- `ci.yml`: removed `⏳ Wait for release workflow` step entirely — CI runs independently
- `update-changelog.yml`: changed concurrency group to `release-changelog`; removed wait-for-release step
- `release.yml`: changed concurrency group to `release-changelog`; removed wait-for-CI/release-drafter/update-changelog step

The shared concurrency group `release-changelog` with `cancel-in-progress: false` means GitHub natively queues `release.yml` and `update-changelog.yml` runs — one waits for the other automatically, zero polling, no circular dependencies.