### PR TITLE
chore: update unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Wait for release workflow in update-changelog to avoid concurrent edits (#182) ([#182](https://github.com/hrzlgnm/actions/pull/182))
 
+- Document that labels are set by ci.yml, not via --label on PR create (#186) ([#186](https://github.com/hrzlgnm/actions/pull/186))
+
 ### Fixed
 
 - Wait for release workflow in ci.yml to prevent race with auto-merge (#184) ([#184](https://github.com/hrzlgnm/actions/pull/184))


### PR DESCRIPTION
Automated update of the `[Unreleased]` section in `CHANGELOG.md`.

This PR is created automatically on every push to `main`
by running `git-cliff` without a version tag.