### PR TITLE
chore: run changelog nightly and create PR as verified github-actions bot

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -4,12 +4,12 @@
 name: "📝 Update Changelog"
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: "0 3 * * *" # Daily at 03:00 UTC
+  workflow_dispatch:
 
 permissions:
-  contents: write # Needed to push to the update branch
+  contents: write # Needed to commit and push to the update branch
   pull-requests: write # Needed to create/update the pull request
 
 concurrency:
@@ -39,43 +39,42 @@ jobs:
       - name: 📝 Generate changelog
         run: git-cliff --output CHANGELOG.md
 
-      - name: ⚙️ Set up SSH signing key
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_SIGNING_KEY }}" > ~/.ssh/id_ed25519_signing
-          chmod 600 ~/.ssh/id_ed25519_signing
-          git config --global gpg.format ssh
-          git config --global user.signingKey ~/.ssh/id_ed25519_signing
-          git config --global user.name "hrzlgnm"
-          git config --global user.email "hrzlgnm@users.noreply.github.com"
-
-      - name: 🔁 Create or update Pull Request
-        env:
-          GH_TOKEN: ${{ secrets.GH_CONTENT_WRITE }}
+      - name: 🔍 Check for changes
+        id: changes
+        shell: bash
         run: |
           if git diff --quiet CHANGELOG.md; then
             echo "No changes to changelog"
-            exit 0
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-          BRANCH="chore/update-changelog"
-          git checkout -B "$BRANCH"
-          git add CHANGELOG.md
-          git commit -S -m "chore(version): update unreleased changelog"
-          git push --force-with-lease origin "$BRANCH"
+      - name: 🖋️ Commit changelog as github-actions[bot]
+        if: steps.changes.outputs.changed == 'true'
+        uses: ryancyq/github-signed-commit@cb9b21ee83578fe8e26a9eda530015aedf0c7c5b # v1.4.1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: CHANGELOG.md
+          commit-message: "chore(version): update unreleased changelog"
+          branch-name: chore/update-changelog
+          branch-push-force: true
 
+      - name: 🔁 Create or update Pull Request
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="chore/update-changelog"
           if [ "$(gh pr list --head "$BRANCH" --state open --json number --jq 'length')" = "0" ]; then
             gh pr create \
               --title "chore: update unreleased changelog" \
               --body "Automated update of the \`[Unreleased]\` section in \`CHANGELOG.md\`.
 
-          This PR is created automatically on every push to \`main\`
+          This PR is created automatically on a nightly schedule
           by running \`git-cliff\` without a version tag." \
               --label ignore
           fi
 
           gh pr merge "$BRANCH" --auto --squash
-
-      - name: 🧹 Cleanup SSH signing key
-        if: always()
-        run: rm -f ~/.ssh/id_ed25519_signing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Collection of reusable GitHub Actions workflows. Published for external consumpt
 
 - **Conventional commits** — All commits follow conventional commits format. `git-cliff` parses them for changelogs.
 - **Semantic versioning** — Tags are `vX.Y.Z`.
-- **SSH-signed commits** — Automated commits use SSH signing key from secrets.
+- **Signed commits** — Changelog commits are authored by `github-actions[bot]` via the GitHub API (Verified). Release version-bump commits use SSH signing key from secrets.
 - **Pinned dependencies** — All actions and tools pinned to SHA commit hashes with version comments (e.g. `# v3`). Renovate keeps them updated.
 - **Copyright + SPDX** — Every workflow file has `# Copyright 2026 hrzlgnm` and `# SPDX-License-Identifier: MIT-0` headers.
 - **`${{ }}` forbidden in `run:` blocks** — Use `env` vars instead.
@@ -21,7 +21,7 @@ Collection of reusable GitHub Actions workflows. Published for external consumpt
 |---|---|---|
 | `ci.yml` | push/PR/schedule | Main CI: detect changes, label PRs, typos, actionlint, alls-green gate |
 | `release-drafter.yml` | push main | Delete old drafts, create new draft release |
-| `update-changelog.yml` | push main | Run git-cliff, open auto-merge PR with changelog update |
+| `update-changelog.yml` | nightly schedule | Run git-cliff, open auto-merge PR with changelog update |
 | `release.yml` | workflow_dispatch | Wait for CI/changelog/drafter, generate final changelog, push, tag, publish |
 | `typos-reusable.yml` | workflow_call | Spell check with `crate-ci/typos` |
 | `actionlint-reusable.yml` | workflow_call | Lint workflow files |
@@ -41,6 +41,6 @@ After making a change, commit, push, and create a PR — then stop. Don't wait f
 
 ## Release process
 
-1. Push to `main` triggers `release-drafter` (drafts release) and `update-changelog` (PR with changelog).
-2. Changelog PR auto-merges, triggering another round of drafter + changelog.
-3. Manually dispatch `release.yml` — it waits for all CI/drafter/changelog to finish, generates final changelog, disables branch protection, pushes tags, publishes the draft, re-enables protection.
+1. Pushing to `main` triggers `release-drafter` (drafts release).
+2. The nightly `update-changelog` workflow opens an auto-merge PR with the unreleased changelog, authored by `github-actions[bot]`.
+3. Manually dispatch `release.yml` — it generates the versioned changelog, disables branch protection, pushes tags, publishes the draft, re-enables protection.


### PR DESCRIPTION
Applies the same pattern as mdns-browser (#2368) and mdns-tui-browser (#497): the changelog PR is created by `github-actions[bot]` with a **Verified** signature.

**Trigger change:** `update-changelog.yml` now runs on a nightly schedule (`0 3 * * *`) + `workflow_dispatch` instead of on every push to `main`.

**Changes in `.github/workflows/update-changelog.yml`:**
- Removed the SSH signing key setup/cleanup (no longer needed).
- Commit `CHANGELOG.md` with `ryancyq/github-signed-commit` (pinned `cb9b21ee` # v1.4.1) using the GraphQL `createCommitOnBranch` mutation with no custom author/committer → GitHub signs it as `github-actions[bot]` → Verified.
- PR creation and auto-merge now use `GITHUB_TOKEN`, so the PR author and the squash-merge commit on `main` are both `github-actions[bot]`.
- Kept `--label ignore`: `release-drafter.yml` uses it as a `pre-exclude` so changelog PRs don't appear in draft release notes. (This intentionally deviates from the AGENTS.md note about not passing `--label`, since the `ignore` label can't be produced by `.github/labeler.yml`.)

**AGENTS.md:** updated the workflows table (trigger) and release process to reflect the nightly changelog flow, and the signing convention (changelog = verified bot commit; release version bump = SSH).

**Requires a repo setting change (UI, no API exists):** enable *Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests* in this repo. The existing changelog PRs are all authored by `hrzlgnm` via a PAT, indicating this is currently disabled. Until enabled, the nightly run will fail at `gh pr create`.

Testing: `actionlint .github/workflows/*.yml` and `typos .` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Changelog updates now run nightly or on demand.
  * Changelog pull requests are automatically created, updated, and merged when changes are detected.
  * Changelog commits use automated signing.

* **Documentation**
  * Updated release documentation to reflect the nightly changelog process and revised signing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->