### PR TITLE
fix: ignore docker digests in typos config

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -7,6 +7,9 @@ extend-exclude = [
 
 [default]
 check-filename = true
+extend-ignore-re = [
+    "digest to [0-9a-f]+", # docker digests in changelog entries
+]
 
 [default.extend-words]
 alls = "alls" # used by re-actors/alls-green action


### PR DESCRIPTION
The changelog now includes `chore(deps)` entries whose docker digests (e.g. `b823ded`) contain substrings typos flags (`ded`, `ba`). Ignore `digest to <hex>` patterns instead of whack-a-mole word additions.