### PR TITLE
ci: trigger bot PR workflow approval on pull_request to main

### DIFF
--- a/.github/workflows/approve-bot-pr-workflows.yml
+++ b/.github/workflows/approve-bot-pr-workflows.yml
@@ -7,15 +7,15 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [requested]
-  schedule:
-    - cron: "0 */4 * * *"
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
   actions: write # needed to approve workflow runs
 
 concurrency:
-  group: approve-bot-pr-workflows
+  group: approve-bot-pr-${{ github.event_name }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
Replace the 4-hour schedule trigger with a `pull_request` trigger targeting `main` so workflow runs on `github-actions[bot]` PRs get approved in a timely manner instead of waiting up to 4 hours.

Also split the concurrency group per event name (`approve-bot-pr-${{ github.event_name }}`) so `workflow_run` and `pull_request` triggers can run in parallel rather than serializing behind a single shared group.

## Changes
- Trigger on `pull_request` to `main` instead of `schedule` cron every 4h
- Concurrency group now keyed by event name

## Testing
- actionlint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow triggers for pull requests targeting the main branch.
  * Removed the scheduled four-hour workflow run.
  * Improved workflow concurrency handling across event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->